### PR TITLE
Support misc headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Now, you can create, update, and delete blog posts just by moving and editing fi
 
 In this way you could, for example, compose and edit blog posts via Markdown in your favorite text editor while sitting by the fire with your laptop in the back of your favorite coffee shop, publishing updates to your blog by hitting _File &rarr; Save_ in your text editor, and not directly interacting with your webserver (or, indeed, with the Plerd software itself) in any way. [What what.](https://vine.co/v/OB5j0jdn1Pt)
 
+## Advanced use
+
+### User-defined attributes
+
+You can add any attributes you'd like to your posts, and then refer to them from your templates via a hash named `attributes` attached to every post object. For example, if a post's metadata looks like this:
+
+    title: Example of user-defined attributes
+    byline: Sam Handwich
+
+Then you can refer to `post.attributes.byline` to fetch that value from within the `post.tt` template file, even though "byline" is not an attribute that Plerd otherwise recognizes. (If a template refers to an attribute key that a post's source file does not define, it will simply return a blank value.)
+
 ## Support
 
 To report bugs or file pull requests, visit [Plerd's GitHub repository](https://github.com/jmacdotorg/plerd).

--- a/lib/Plerd/Post.pm
+++ b/lib/Plerd/Post.pm
@@ -208,7 +208,7 @@ sub _process_source_file {
     # Slurp the file, storing the title and time metadata, and the body.
     my $fh = $self->source_file->openr;
     my %attributes;
-    my @ordered_attribute_names = qw( time title published_filename guid );
+    my @ordered_attribute_names = qw( title time published_filename guid );
     while ( my $line = <$fh> ) {
         chomp $line;
         last unless $line =~ /\S/;

--- a/lib/Plerd/Post.pm
+++ b/lib/Plerd/Post.pm
@@ -445,7 +445,7 @@ String representing the post's body text.
 A hashref of all the attributes defined in the source document's metadata
 section, whether or not Plerd takes any special meaning from them.
 
-For example, if a source document defines both C<title> and C<favorite-color>
+For example, if a source document defines both C<title> and C<favorite_color>
 key-value pairs in its metadata, both keys and values will appear in this
 hashref, even though Plerd pays no mind to the latter key.
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -135,6 +135,18 @@ like ( $source_file->slurp,
        'Source file contains a GUID, as expected.',
 );
 
+### Test miscellaneous-attribute pass-through
+my $byline_post =
+    Path::Class::File->new(
+        $docroot_dir,
+        '2000-01-01-this-post-has-extra-headers.html',
+    );
+
+like( $byline_post->slurp,
+      qr/"byline">Sam Handwich/,
+      'Miscellaneous header passed through to the template',
+);
+
 }
 
 ### Test using alternate config paths
@@ -157,7 +169,6 @@ is( scalar( $docroot_dir->children ),
             $expected_docroot_count,
             "Correct number of files generated in docroot."
 );
-
-
 }
+
 done_testing();

--- a/t/source_model/extra-headers.md
+++ b/t/source_model/extra-headers.md
@@ -1,0 +1,8 @@
+title: This post has extra headers
+time: 2000-01-01T00:00:00-05:00
+byline: Sam Handwich
+color: Green
+
+Doop de doo! The body of this post is not important for this test.
+
+How do you do.

--- a/t/templates/post.tt
+++ b/t/templates/post.tt
@@ -3,6 +3,7 @@
 [% FOREACH post IN posts %]
 <div class="post">
     <div class="title page-header"><h1><a href="[% post.uri %]">[% post.title %]<br /><small>[% post.month_name %] [% post.day %], [% post.year %]</small></a></h1></div>
+    <div class="byline">[% post.attributes.byline %]</div>
     <div class="body">[% post.body %]</div>
 </div>
 [% END %]


### PR DESCRIPTION
Adds support for user-defined headers in Markdown source files. They get passed along for templates' use within an "attributes" hash attached to every post object.
