### PR TITLE
Fallback to finding plerd config via cwd.

### DIFF
--- a/bin/plerdall
+++ b/bin/plerdall
@@ -22,7 +22,23 @@ GetOptions(
     'rebuild-webmentions' => \$rebuild_webmentions,
 );
 
-my $config_ref = LoadFile( "$FindBin::Bin/../conf/plerd.conf" );
+my $config_ref = eval { LoadFile( "$FindBin::Bin/../conf/plerd.conf" ) };
+if (!$config_ref) {
+    use Cwd;
+    use Path::Class::Dir;
+    my $config_path = Path::Class::Dir->new(cwd());
+    until ($config_ref) {
+        $config_ref = eval { LoadFile("$config_path/conf/plerd.conf") };
+        unless ($config_ref) {
+            $config_ref = eval { LoadFile("$config_path/plerd.conf") };
+        }
+    } continue {
+        my $new_path = $config_path->parent;
+        die "Could not find plerd.conf in " . Path::Class::Dir->new($FindBin::Bin, '../conf') . " or in " . cwd() . " or any of its parent directories"
+            if $new_path eq $config_path;
+        $config_path = $new_path;
+    }
+}
 
 foreach (qw( base_uri image ) ) {
     unless ( ref $config_ref->{ $_ } ) {

--- a/bin/plerdwatcher
+++ b/bin/plerdwatcher
@@ -33,7 +33,23 @@ GetOptions(
 my $webserver_pid;
 $SIG{TERM} = \&handle_term_signal;
 
-my $config_ref = LoadFile( "$FindBin::Bin/../conf/plerd.conf" );
+my $config_ref = eval { LoadFile( "$FindBin::Bin/../conf/plerd.conf" ) };
+if (!$config_ref) {
+    use Cwd;
+    use Path::Class::Dir;
+    my $config_path = Path::Class::Dir->new(cwd());
+    until ($config_ref) {
+        $config_ref = eval { LoadFile("$config_path/conf/plerd.conf") };
+        unless ($config_ref) {
+            $config_ref = eval { LoadFile("$config_path/plerd.conf") };
+        }
+    } continue {
+        my $new_path = $config_path->parent;
+        die "Could not find plerd.conf in " . Path::Class::Dir->new($FindBin::Bin, '../conf') . " or in " . cwd() . " or any of its parent directories"
+            if $new_path eq $config_path;
+        $config_path = $new_path;
+    }
+}
 
 foreach ( qw( run log ) ) {
     mkdir "$FindBin::Bin/../$_/" unless -e "$FindBin::Bin/../$_/";


### PR DESCRIPTION
Allows a single set of plerd bins to used for multiple plerd instances, by
scanning for configs relative to the CWD if one relative to the bins isn't
found.

What it does is look for `conf/plerd.conf` and `plerd.conf` in CWD and all parent directories. This lets me keep my plerd.conf with my drafts, publish, docroot and templates. Because this is a fallback, existing use should be unaffected.