### PR TITLE
Extension support

### DIFF
--- a/bin/plerdall
+++ b/bin/plerdall
@@ -57,13 +57,6 @@ foreach (qw( base_uri image ) ) {
     }
 }
 
-
-my @extensions = $config_ref->{ extensions }
-    ? split(',', $config_ref->{ extensions })
-    : ();
-
-$config_ref->{ extensions } = \@extensions;
-
 my $plerd = Plerd->new( $config_ref );
 
 if ( $rebuild_webmentions ) {

--- a/bin/plerdall
+++ b/bin/plerdall
@@ -57,6 +57,13 @@ foreach (qw( base_uri image ) ) {
     }
 }
 
+
+my @extensions = $config_ref->{ extensions }
+    ? split(',', $config_ref->{ extensions })
+    : ();
+
+$config_ref->{ extensions } = \@extensions;
+
 my $plerd = Plerd->new( $config_ref );
 
 if ( $rebuild_webmentions ) {

--- a/bin/plerdwatcher
+++ b/bin/plerdwatcher
@@ -78,7 +78,7 @@ try {
 
     $watcher = File::ChangeNotify->instantiate_watcher (
         directories => [ $plerd->source_directory . '' ],
-        filter      => qr/\.(md|markdown)$/,
+        filter      => qr/\.(md|markdown|jpe?g)$/,
     );
 }
 catch {

--- a/bin/plerdwatcher
+++ b/bin/plerdwatcher
@@ -71,14 +71,28 @@ foreach (qw( base_uri image ) ) {
     }
 }
 
+my @extensions = $config_ref->{ extensions }
+    ? split(',', $config_ref->{ extensions })
+    : ();
+
+$config_ref->{ extensions } = \@extensions;
+
+
 my $plerd;
 my $watcher;
 try {
     $plerd = Plerd->new( $config_ref );
+    my $filter;
+
+    my $trigger = defined (keys %{$plerd->post_triggers})
+        ? sprintf '\.(md|markdown|%s)$', join('|', keys %{$plerd->post_triggers})
+        : '\.(md|markdown)$';
+
+    $filter = qr/$trigger/;
 
     $watcher = File::ChangeNotify->instantiate_watcher (
         directories => [ $plerd->source_directory . '' ],
-        filter      => qr/\.(md|markdown|jpe?g)$/,
+        filter      => $filter,
     );
 }
 catch {

--- a/bin/plerdwatcher
+++ b/bin/plerdwatcher
@@ -71,13 +71,6 @@ foreach (qw( base_uri image ) ) {
     }
 }
 
-my @extensions = $config_ref->{ extensions }
-    ? split(',', $config_ref->{ extensions })
-    : ();
-
-$config_ref->{ extensions } = \@extensions;
-
-
 my $plerd;
 my $watcher;
 try {

--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,7 @@ requires 'Try::Tiny';
 requires 'HTML::Strip';
 requires 'HTML::SocialMeta' => '0.72';
 requires 'List::Util' => '1.45';
+requires 'Module::Load';
 requires 'Readonly';
-requires 'Web::Mention' => '0.6'; 
+requires 'Web::Mention' => '0.6';
 requires 'Mojolicious::Lite';

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -297,7 +297,8 @@ sub BUILD {
             load $extension;
         }
         catch {
-            die "Can't load extension: '$extension'.: $@";
+            my $error = shift || "Unknown error";
+            die "Can't load extension: '$extension': $error\n";
         };
     }
 

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -261,12 +261,12 @@ has 'tags_map' => (
 
 has 'extensions' => (
     is => 'ro',
-    isa => 'ArrayRef[Str]',
+    isa => 'Maybe[ArrayRef[Str]]',
 );
 
 has 'post_triggers' => (
     is => 'ro',
-    isa => 'HashRef[Str]',
+    isa => 'Maybe[HashRef[Str]]',
     lazy_build => 1,
     );
 
@@ -286,15 +286,14 @@ sub BUILD {
             };
         }
     }
-    if ($self->extensions){
-        foreach my $extension (@{$self->extensions}) {
-            try {
-                load $extension;
-            }
-            catch {
-                die "Can't load extension: '$extension'.: $@";
-            };
+
+    foreach my $extension (@{$self->extensions // []}) {
+        try {
+            load $extension;
         }
+        catch {
+            die "Can't load extension: '$extension'.: $@";
+        };
     }
 
     return $self;
@@ -699,13 +698,13 @@ sub _throw_template_exception {
 sub _build_post_triggers {
     my $self = shift;
     my %triggers;
-    if ($self->extensions){
-        foreach my $classref (@{$self->extensions}){
-            if ($classref->can('file_type')) {
-                $triggers{ $classref->file_type } = $classref;
-            }
+
+    foreach my $classref (@{$self->extensions // []}){
+        if ($classref->can('file_type')) {
+            $triggers{ $classref->file_type } = $classref;
         }
     }
+
     return \%triggers;
 }
 

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -640,7 +640,7 @@ sub _build_posts {
             push @posts, Plerd::Post->new( plerd => $self, source_file => $file )
         } else {
             foreach my $trigger (keys %{$triggers}) {
-                if ($file =~ m/$trigger/i) {
+                if ($file =~ m/\.$trigger$/i) {
                     push @posts, $$triggers{$trigger}->new(plerd => $self, source_file => $file);
                 }
             }

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -1006,7 +1006,7 @@ particularly helpful when creating navigation.
 
 =item extensions
 
-An arrayref of L<Str> objects, representing the plugins to load when a new Pled
+An arrayref of strings, representing the plugins to load when a new Plerd
 instance is created.
 
 =item extension_preferences
@@ -1016,7 +1016,7 @@ to decide how to act upon the contents therein.
 
 =item post_triggers
 
-A hashref of L<Str>,L<Str> objects. The key is used as a regex to deduce what
+A hashref that maps extensions to file types. The key is used as a regex to deduce what
 source file types the particular Post extension using to render pages.
 The value is a reference to that particular extension.
 

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -261,14 +261,19 @@ has 'tags_map' => (
 
 has 'extensions' => (
     is => 'ro',
-    isa => 'Maybe[ArrayRef[Str]]',
+    isa => 'Maybe[ArrayRef[Str]]'
+);
+
+has 'extension_preferences' => (
+    is => 'ro',
+    isa => 'Maybe[HashRef]',
 );
 
 has 'post_triggers' => (
     is => 'ro',
     isa => 'Maybe[HashRef[Str]]',
     lazy_build => 1,
-    );
+);
 
 
 sub BUILD {
@@ -1003,6 +1008,11 @@ particularly helpful when creating navigation.
 
 An arrayref of L<Str> objects, representing the plugins to load when a new Pled
 instance is created.
+
+=item extension_preferences
+
+A hashref of config options for extensions. It is up to each individual extension
+to decide how to act upon the contents therein.
 
 =item post_triggers
 

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -13,6 +13,7 @@ use Carp;
 use Try::Tiny;
 
 use Plerd::Post;
+use InstaPlerd::Post;
 use Plerd::WebmentionQueue;
 
 has 'path' => (

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -642,6 +642,7 @@ sub _build_posts {
             foreach my $trigger (keys %{$triggers}) {
                 if ($file =~ m/\.$trigger$/i) {
                     push @posts, $$triggers{$trigger}->new(plerd => $self, source_file => $file);
+                    last;
                 }
             }
         }

--- a/t/basic.t
+++ b/t/basic.t
@@ -351,7 +351,7 @@ $extension_plerd->publish_all;
 
 my $post = Path::Class::File->new( $docroot_dir, "$ymd-a-very-special-source-file.html" )->slurp;
 like( $post,
-    qr{.dm which is .md backwards.},
+    qr{.sdrawkcab dm. si hcihw md.},
     'Extensions: Plerd can publish with extensions',
 );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -336,8 +336,6 @@ like( $post,
 }
 {
 ### Test extension-support
-use lib 'src';
-use TestExtension;
 my $extension_plerd = Plerd->new(
     path         => $FindBin::Bin,
     title        => 'Test Blog',

--- a/t/basic.t
+++ b/t/basic.t
@@ -55,7 +55,7 @@ unlink "$FindBin::Bin/source/no-title.md";
 
 $plerd->publish_all;
 
-# The "+5" below accounts for the generated recent, archive, and RSS files,
+# The "+4" below accounts for the generated recent, archive, and RSS files,
 # a index.html symlink, and a tags directory.
 my $expected_docroot_count = scalar( $source_dir->children( no_hidden => 1 ) ) + 4;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -349,7 +349,7 @@ my $extension_plerd = Plerd->new(
 
 $extension_plerd->publish_all;
 
-my $post = Path::Class::File->new( $docroot_dir, "2018-11-10-a-very-special-source-file.html" )->slurp;
+my $post = Path::Class::File->new( $docroot_dir, "$ymd-a-very-special-source-file.html" )->slurp;
 like( $post,
     qr{.dm which is .md backwards.},
     'Extensions: Plerd can publish with extensions',

--- a/t/basic.t
+++ b/t/basic.t
@@ -8,6 +8,7 @@ use DateTime;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/lib";
 
 use_ok( 'Plerd' );
 
@@ -56,7 +57,8 @@ $plerd->publish_all;
 
 # The "+5" below accounts for the generated recent, archive, and RSS files,
 # a index.html symlink, and a tags directory.
-my $expected_docroot_count = scalar( $source_dir->children( no_hidden => 1 ) ) + 5;
+my $expected_docroot_count = scalar( $source_dir->children( no_hidden => 1 ) ) + 4;
+
 is( scalar( $docroot_dir->children ),
             $expected_docroot_count,
             "Correct number of files generated in docroot."
@@ -329,6 +331,30 @@ $post = Path::Class::File->new( $docroot_dir, "$ymd-metatags.html" )->slurp;
 like( $post,
     qr{name="twitter:image:alt" content="Just a test image."},
     'Metatags: Defined default alt-text',
+);
+
+}
+{
+### Test extension-support
+use lib 'src';
+use TestExtension;
+my $extension_plerd = Plerd->new(
+    path         => $FindBin::Bin,
+    title        => 'Test Blog',
+    author_name  => 'Nobody',
+    author_email => 'nobody@example.com',
+    extensions   => ['TestExtension'],
+    base_uri     => URI->new ( 'http://blog.example.com/' ),
+    image        => URI->new ( 'http://blog.example.com/logo.png' ),
+
+);
+
+$extension_plerd->publish_all;
+
+my $post = Path::Class::File->new( $docroot_dir, "2018-11-10-a-very-special-source-file.html" )->slurp;
+like( $post,
+    qr{.dm which is .md backwards.},
+    'Extensions: Plerd can publish with extensions',
 );
 
 }

--- a/t/lib/TestExtension.pm
+++ b/t/lib/TestExtension.pm
@@ -1,0 +1,13 @@
+package TestExtension;
+use Plerd::Post;
+use Moose;
+use strict;
+use warnings FATAL => 'all';
+
+extends "Plerd::Post";
+
+sub file_type {
+    'dm';
+}
+
+1;

--- a/t/lib/TestExtension.pm
+++ b/t/lib/TestExtension.pm
@@ -2,6 +2,9 @@ package TestExtension;
 use Plerd::Post;
 use Moose;
 use strict;
+
+use 5.010;
+
 use warnings FATAL => 'all';
 
 extends "Plerd::Post";
@@ -10,4 +13,56 @@ sub file_type {
     'dm';
 }
 
+around 'body' => sub {
+    my $orig = shift;
+    my $self = shift;
+    if (@_){
+        # "Setter"
+        my $body = shift;
+
+        # first time body is called, reverse it!
+        $body = reverse $body unless $self->$orig;
+
+        $self->$orig($body);
+    } else {
+        # "Getter"
+        $self->$orig();
+    }
+};
+
 1;
+
+
+=head1 NAME
+
+TestExtension - A L<Plerd::Post> extension to showcase the extension capabilities of L<Plerd>.
+
+=head1 DESCRIPTION
+
+This extension doesn't do anything truly useful. It's sole purpose is showcasing the extension capabilities.
+
+What it does in fact do, though, is reversing the body of the document (the first time it's set).
+
+It's rather useless.
+
+=head1 OBJECT ATTRIBUTES
+
+=head2 Read-only attributes, set during construction
+
+=over
+
+=item file_type
+
+A regex-compatible string which indicate what file types to associate with the Extension.
+This is set to "dm" (which happens to be "md" spelled backwards)
+
+=item body
+
+The original L<Plerd::Post> body, except that the first time this attribute is set, it gets reversed.
+
+=back
+
+=head2 Other attributes
+
+All other attributes are inherited from L<Plerd::Post> Please consult that documentation for their docs.
+

--- a/t/source_model/extension.dm
+++ b/t/source_model/extension.dm
@@ -1,0 +1,4 @@
+title: A very special source file
+
+
+It's only special because it's file type is .dm which is .md backwards. This is to see if it gets processed by an extension.


### PR DESCRIPTION
This is my suggestion for adding extension support for Plerd. I use this  to load [Instaplerd](https://github.com/doddo/instaplerd) which can parse jpegs and render images with various creative filters and such, (but its rather new so I have only made one filter so far). You can see it in production on [my homepage](https://www.petter.re/), to get an idea of the thing.

I was trying to make this PR into something reusable, so that you can make blog posts from any source imaginable, as long as it's got an extension which implements the methods in Plerd::Post (there's a quite good example of this in the t folder), and has a "static" file_type method which can be used to deduce what files it likes. 