### PR TITLE
Minor fix: MultiMarkDown link on Readme was not encoded properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Once you've configured your blog as described above, you can add these attribute
 
 ### MultiMarkdown
 
-Plerd supports \[MultiMarkdown\](https://fletcherpenney.net/multimarkdown/) syntax out of the box! Go ahead and put MultiMarkdown tables and stuff into your posts. it'll just work.
+Plerd supports [MultiMarkdown](https://fletcherpenney.net/multimarkdown/) syntax out of the box! Go ahead and put MultiMarkdown tables and stuff into your posts. it'll just work.
 
 ### Webmention
 

--- a/README.pod
+++ b/README.pod
@@ -303,7 +303,7 @@ B<image_alt>: A textual description of the image referenced by the C<image> attr
 
 =head3 MultiMarkdown
 
-Plerd supports [MultiMarkdown](https://fletcherpenney.net/multimarkdown/) syntax out of the box! Go ahead and put MultiMarkdown tables and stuff into your posts. it'll just work.
+Plerd supports L<MultiMarkdown|https://fletcherpenney.net/multimarkdown/> syntax out of the box! Go ahead and put MultiMarkdown tables and stuff into your posts. it'll just work.
 
 =head3 Webmention
 


### PR DESCRIPTION
Hi Jason! Thanks a lot for maintaining Plerd!

I have found a very minor thing in latest release: README.md was not displaying link to MultiMarkDown site properly. I've found this was because README.pod had `[this](syntax)` as opposed to `L<this|syntax>`, so it was being rendered `\[like\](this)`.

Let me know if you think issue is caused by something else and needs a more thorough fix. Thanks!