### PR TITLE
fixed nav: added link to tags view; make anchors qualified

### DIFF
--- a/lib/Plerd/Init.pm
+++ b/lib/Plerd/Init.pm
@@ -380,8 +380,9 @@ wrapper => <<EOF,
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li><a href="archive.html">Archive</a></li>
-                    <li><a href="atom.xml">RSS</a></li>
+                    <li><a href="/archive.html">Archive</a></li>
+                    <li><a href="/tags/">Tags</a></li>
+                    <li><a href="/atom.xml">RSS</a></li>
                 </ul>
             </div><!--/.navbar-collapse -->
         </div>


### PR DESCRIPTION
This patch changes the default layout template ('wrapper.tt') to make
the nav bar at the top contain a link to the /tags/ view.  It also
changes the links to 'recent.html' and 'atom.xml' to be anchor at the
docroot's base.  This is needed so that the nav works from inside the
/tags/ view.