### PR TITLE
Fix README generation: restore CI badge and correct "Sweat" typo at the POD source

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Plerd
 
 {{$NEXT}}
 
+      - Fixed README generation: the CI badge and an "install Sweat"
+        copypasta typo are now corrected at the README.pod source, since
+        README.md is generated from it by Minilla.
+
 1.900 2026-06-19T17:35:40Z
 
       - Incremental publishing: plerdwatcher now republishes incrementally on a

--- a/META.json
+++ b/META.json
@@ -80,7 +80,7 @@
          "web" : "https://github.com/jmacdotorg/plerd"
       }
    },
-   "version" : "1.900",
+   "version" : "1.901",
    "x_authority" : "cpan:JMAC",
    "x_contributors" : [
       "Christian Sánchez <sanchezchristian@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Test](https://github.com/jmacdotorg/plerd/actions/workflows/test.yml/badge.svg)](https://github.com/jmacdotorg/plerd/actions/workflows/test.yml)
 # Plerd 
 
 Plerd is meant to be an ultralight blogging platform for Markdown fans that plays well with (but does not require) Dropbox.
@@ -40,7 +41,7 @@ If you run into issues due to failing dependencies, you can try one of these ins
     # or
     cpanm --force Plerd
 
-Alternately, you can run these commands under \`sudo\` to install Sweat at the system level.
+Alternately, you can run these commands under \`sudo\` to install Plerd at the system level.
 
 If everything installed as it should, then you should have the `plerdall` and `plerdwatcher` programs in your command path.
 

--- a/README.pod
+++ b/README.pod
@@ -1,7 +1,8 @@
 =encoding utf8
 
+=for markdown [![Test](https://github.com/jmacdotorg/plerd/actions/workflows/test.yml/badge.svg)](https://github.com/jmacdotorg/plerd/actions/workflows/test.yml)
 
-=head1 Plerd 
+=head1 Plerd
 
 Plerd is meant to be an ultralight blogging platform for Markdown fans that plays well with (but does not require) Dropbox.
 
@@ -45,7 +46,7 @@ If you run into issues due to failing dependencies, you can try one of these ins
  # or
  cpanm --force Plerd
 
-Alternately, you can run these commands under `sudo` to install Sweat at the system level.
+Alternately, you can run these commands under `sudo` to install Plerd at the system level.
 
 If everything installed as it should, then you should have the C<plerdall> and C<plerdwatcher> programs in your command path.
 

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -1,6 +1,6 @@
 package Plerd;
 
-our $VERSION = '1.900';
+our $VERSION = '1.901';
 
 use Moose;
 use MooseX::Types::URI qw(Uri);


### PR DESCRIPTION
## Summary

`README.md` is a generated artifact, built from `README.pod` by Minilla (`readme_from="README.pod"` in `minil.toml`, via Pod::Markdown). Hand-edits to `README.md` are therefore overwritten on every `minil build`/release, so durable fixes must go in `README.pod`.

This fixes two issues that surfaced when the 1.900 release regenerated `README.md` from a stale `README.pod`:

- **"Sweat" typo** — `README.pod` carried an "install Sweat" copypasta typo since 2020. The 2020 "Oops, copypasta" fix (`63757e4`) corrected only the generated `README.md`, leaving the source POD wrong; the 1.900 regeneration re-imported it. Now fixed at the source.
- **Missing CI badge** — the GitHub Actions badge had only ever been hand-added to `README.md` (`358066a`), so regeneration stripped it. Re-added to `README.pod` as a `=for markdown` passthrough block so it survives future regeneration.
- `README.md` is updated to match what regeneration now produces.

## Verification

Ran `README.pod` through Pod::Markdown (the same path `Minilla/Project.pm` `regenerate_readme_md` uses):
- badge present at top ✓
- "install Plerd at the system level" ✓
- zero occurrences of "Sweat" ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)