### PR TITLE
Don't die when tags.tt is missing (#41)

### DIFF
--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -497,6 +497,17 @@ sub neighbor_basename {
 sub publish_tag_indexes {
     my $self = shift;
 
+    # tags.tt is the one non-critical template: if it's missing, publish the
+    # rest of the blog anyway rather than dying. Warn only if the blog actually
+    # uses tags and therefore loses content by skipping their pages.
+    unless ( -e $self->tags_template_file ) {
+        if ( $self->has_tags ) {
+            carp "This blog uses tags, but its template directory has no "
+                 . "tags.tt file. Skipping publication of tag pages.\n";
+        }
+        return;
+    }
+
     my $tag_map = $self->tags_map;
 
     # Commentary: Ideally we'd just pass a sorted array of tag objects

--- a/t/missing_tags_template.t
+++ b/t/missing_tags_template.t
@@ -1,0 +1,76 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Warn;
+use Path::Class::Dir;
+use Path::Class::File;
+use URI;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use_ok( 'Plerd' );
+use Plerd::Init;
+
+# Regression test for GitHub issue #41: tags.tt is the one non-critical
+# template. If it's missing, the blog should still publish. It should publish
+# silently when the blog has no tags, and warn (rather than die) when the blog
+# does use tags but can't render their pages.
+
+sub fresh_blog {
+    my ( $name ) = @_;
+    my $blog_dir = Path::Class::Dir->new( "$FindBin::Bin/$name" );
+    $blog_dir->rmtree;
+    Plerd::Init::initialize( $blog_dir->stringify, 0 );
+
+    # Remove the tags template to simulate a blog that lacks it.
+    Path::Class::File->new( $blog_dir, 'templates', 'tags.tt' )->remove;
+
+    my $plerd = Plerd->new(
+        path         => $blog_dir->stringify,
+        title        => 'Test Blog',
+        author_name  => 'Nobody',
+        author_email => 'nobody@example.com',
+        base_uri     => URI->new( 'http://blog.example.com/' ),
+    );
+    return ( $blog_dir, $plerd );
+}
+
+# Case 1: a blog with no tags at all.
+{
+    my ( $blog_dir, $plerd ) = fresh_blog( 'no_tags_blog' );
+    my $source = Path::Class::File->new( $blog_dir, 'source', '2018-01-01-hello.md' );
+    $source->spew( iomode => '>:encoding(utf8)', "title: Hello\n\nNo tags here.\n" );
+
+    warning_is { eval { $plerd->publish_all } } undef,
+        'Publishing a tag-free blog without tags.tt produces no warning.';
+    is( $@, '', 'Publishing a tag-free blog without tags.tt does not die.' );
+    ok(
+        -e Path::Class::File->new( $blog_dir, 'docroot', '2018-01-01-hello.html' ),
+        'The post still published.'
+    );
+
+    $blog_dir->rmtree;
+}
+
+# Case 2: a blog that does use tags.
+{
+    my ( $blog_dir, $plerd ) = fresh_blog( 'tagged_blog' );
+    my $source = Path::Class::File->new( $blog_dir, 'source', '2018-01-02-tagged.md' );
+    $source->spew(
+        iomode => '>:encoding(utf8)',
+        "title: Tagged\ntags: foo, bar\n\nThis post has tags.\n"
+    );
+
+    warning_like { eval { $plerd->publish_all } } qr/tags\.tt/,
+        'Publishing a tagged blog without tags.tt warns about the missing template.';
+    is( $@, '', 'Publishing a tagged blog without tags.tt does not die.' );
+    ok(
+        -e Path::Class::File->new( $blog_dir, 'docroot', '2018-01-02-tagged.html' ),
+        'The post still published.'
+    );
+
+    $blog_dir->rmtree;
+}
+
+done_testing();


### PR DESCRIPTION
Closes #41.

## Diagnosis
`tags.tt` is arguably the one non-critical template, but a blog with **no tags at all** still died to publish without it:

```
Can't open template file .../templates/tags.tt for reading: No such file or directory
```

The cause: `publish_tag_indexes` renders the tag *index* page unconditionally (even when the tag map is empty), so the missing template is touched on every publish regardless of whether the blog uses tags.

## Fix
Guard `publish_tag_indexes`: if `tags.tt` doesn't exist, skip tag-page publication and let the rest of the blog publish. Warn (via `carp`) — rather than die — only when the blog actually uses tags and is therefore losing content by skipping their pages.

## Test
Adds `t/missing_tags_template.t` with two cases, both with `tags.tt` removed:
- a tag-free blog publishes **silently** and produces its post;
- a tagged blog publishes with a **warning** matching `/tags\.tt/` and still produces its post.

Both died before the fix; both pass now. Full suite green (84 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)