### PR TITLE
Point index.html symlink at recent.html by basename (#54)

### DIFF
--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -562,9 +562,6 @@ sub publish_recent_page {
         $self->publication_directory, "index.html.$$.tmp"
     );
     $temp_link->remove if -e $temp_link || -l $temp_link;
-    # Link to recent.html by basename: index.html sits beside it in the docroot,
-    # so a relative sibling target stays correct whether the docroot is named by
-    # an absolute or relative path, and survives the whole tree being moved.
     if ( symlink $self->recent_file->basename, $temp_link ) {
         rename "$temp_link", "$index_file"
             or warn "Couldn't move the index.html symlink into place: $!\n";

--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -562,7 +562,10 @@ sub publish_recent_page {
         $self->publication_directory, "index.html.$$.tmp"
     );
     $temp_link->remove if -e $temp_link || -l $temp_link;
-    if ( symlink $self->recent_file, $temp_link ) {
+    # Link to recent.html by basename: index.html sits beside it in the docroot,
+    # so a relative sibling target stays correct whether the docroot is named by
+    # an absolute or relative path, and survives the whole tree being moved.
+    if ( symlink $self->recent_file->basename, $temp_link ) {
         rename "$temp_link", "$index_file"
             or warn "Couldn't move the index.html symlink into place: $!\n";
     }

--- a/t/index_symlink.t
+++ b/t/index_symlink.t
@@ -1,0 +1,47 @@
+use warnings;
+use strict;
+use Test::More;
+use Path::Class::Dir;
+use Path::Class::File;
+use URI;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use_ok( 'Plerd' );
+use Plerd::Init;
+
+# Regression test for GitHub issue #54: the docroot/index.html symlink must
+# point at its sibling "recent.html" by basename, not at a path that includes
+# the docroot directory. A target like "docroot/recent.html" resolves to
+# docroot/docroot/recent.html from inside docroot and leaves index.html broken.
+
+my $blog_dir = Path::Class::Dir->new( "$FindBin::Bin/index_symlink_blog" );
+$blog_dir->rmtree;
+Plerd::Init::initialize( $blog_dir->stringify, 0 );
+
+Path::Class::File->new( $blog_dir, 'source', '2021-01-01-hello.md' )->spew(
+    iomode => '>:encoding(utf8)',
+    "title: Hello\n\nBody.\n",
+);
+
+my $plerd = Plerd->new(
+    path         => $blog_dir->stringify,
+    title        => 'Test Blog',
+    author_name  => 'Nobody',
+    author_email => 'nobody@example.com',
+    base_uri     => URI->new( 'http://blog.example.com/' ),
+);
+
+$plerd->publish_all;
+
+my $index = Path::Class::File->new( $blog_dir, 'docroot', 'index.html' );
+
+ok( -l $index, 'docroot/index.html is a symlink.' );
+is( readlink( "$index" ), 'recent.html',
+    'index.html points at its sibling recent.html by basename.' );
+ok( -e $index, 'index.html resolves to an existing file.' );
+
+$blog_dir->rmtree;
+
+done_testing();


### PR DESCRIPTION
Closes #54.

## Diagnosis
`publish_recent_page` created the `docroot/index.html` symlink with `recent_file`'s **full path** as the target:

```perl
symlink $self->recent_file, $temp_link
```

When the blog's docroot is named by a relative path, `recent_file` stringifies to something like `docroot/recent.html`. Since the symlink lives *inside* docroot, that target resolves to `docroot/docroot/recent.html` — so `index.html` dangles. (This is exactly what the reporter saw: `index.html -> docroot/recent.html`.) Even with an absolute path the link technically resolved but was non-portable — it broke if the published tree was moved or served from a different mount.

## Fix
`index.html` sits right beside `recent.html` in the docroot, so link to it by **basename**:

```perl
symlink $self->recent_file->basename, $temp_link
```

A relative sibling target is correct whether the docroot is configured with an absolute or relative path, and survives the whole tree being relocated.

## Test
Adds `t/index_symlink.t`: after publishing, asserts `docroot/index.html` is a symlink, that `readlink` returns exactly `recent.html`, and that it resolves to an existing file. The `readlink` assertion failed before the fix (the target was the full path); all pass now. Also verified end-to-end against the reporter's relative-path scenario. Full suite green (81 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)