### PR TITLE
Mark master as post-1.901 development (1.901_001)

### DIFF
--- a/lib/Plerd.pm
+++ b/lib/Plerd.pm
@@ -1,6 +1,6 @@
 package Plerd;
 
-our $VERSION = '1.901';
+our $VERSION = '1.901_001';
 
 use Moose;
 use MooseX::Types::URI qw(Uri);


### PR DESCRIPTION
Sets `$VERSION` in `lib/Plerd.pm` to a developer (underscore) version so master stops claiming to be the released `1.901` while it accumulates the pending bug-fix merges (#66–#71).

- The underscore makes PAUSE treat it as a **non-indexed trial/dev** version, so a `cpanm`-from-git install won't masquerade as stable 1.901.
- `1.901_001` numifies to `1.901001`, which sorts **after** `1.901` and **before** the eventual `1.902` stable release. (Anchoring on `1.901` rather than `1.902` is deliberate: `1.902_001` would numify to `1.902001` and sort *ahead* of the real `1.902`.)
- The next stable release drops the underscore and becomes `1.902`.

Changelog entries for the individual fixes are intentionally **not** here — each fix PR adds its own `{{$NEXT}}` line so the entry lands with the code that justifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)